### PR TITLE
Add various extra props, refactor arguments to search providers, provide support for older browsers, fix scroll and click propogation issues

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -5,7 +5,10 @@
         {
           "targets": {
             "node": "current",
-            "browsers": ["last 2 Chrome versions"]
+            "browsers": [
+              "last 2 versions",
+              "ios 9"
+            ]
           },
           "modules": "commonjs",
           "loose": true

--- a/README.md
+++ b/README.md
@@ -83,9 +83,14 @@ Other aspects can be customized as well:
   inputPlaceholder="The default text in the search bar"
   showMarker={true}
   showPopup={false}
+  openSearchOnLoad={false}
+  closeResultsOnClick={false}
 />
 ```
 
+The `openSearchOnLoad` prop allows you to show the search bar instead of the search icon by default.
+
+The `closeResultsOnClick` prop will hide the results when you've clicked on one, which saves screen space on a dense map. Focussing on the search input will show the previous results again (without an extra search).
 
 ## Info about search input
 It has two modes:

--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ const searchComponent = props => (
 )
 ```
 
-The default provider is OpenStreetMap. If you want to use BingMap as a provider, it can be done as follows:
+### Search providers
+
+There are 2 search providers, but with scope for adding more.  The default provider is OpenStreetMap. If you want to use BingMap as a provider, it can be done as follows:
 ```javascript
 const searchComponent = props => (
   <ReactLeafletSearch
@@ -40,7 +42,18 @@ const searchComponent = props => (
             providerKey="{BINGMAP_KEY}" />
 )
 ```
-For now, react-leaflet-search only has two providers, but more will be added in the future.
+
+You can pass in provider-specific options using the providerOptions prop:
+```javascript
+const searchComponent = props => (
+  <ReactLeafletSearch
+            position="topleft"
+            provider="OpenStreetMap"
+            providerOptions={{region: 'gb'}} />
+)
+```
+
+### Search Result Marker
 
 To change the marker icon, use the markerIcon prop:
 ```javascript
@@ -74,7 +87,7 @@ myPopup(SearchInfo) {
 
 <ReactLeafletSearch position="topleft" popUp={ myPopup }/>
 ```
-
+### Other props which can be set on the `ReactLeafletSearch` component
 Other aspects can be customized as well:
 
 ```javascript
@@ -83,18 +96,11 @@ Other aspects can be customized as well:
   inputPlaceholder="The default text in the search bar"
   showMarker={true}
   showPopup={false}
-  openSearchOnLoad={false}
-  closeResultsOnClick={false}
-  searchBounds={[]}
+  openSearchOnLoad={false} // By default there's a search icon which opens the input when clicked. Setting this to true opens the search by default.
+  closeResultsOnClick={false} // By default, the search results remain when you click on one, and the map flies to the location of the result. But you might want to save space on your map by closing the results when one is clicked. The results are shown again (without another search) when focus is returned to the search input.
+  searchBounds={[]} // The BingMap and OpenStreetMap providers both accept bounding coordinates in [se,nw] format. Note that in the case of OpenStreetMap, this only weights the results and doesn't exclude things out of bounds.
 />
 ```
-
-The `openSearchOnLoad` prop allows you to show the search bar instead of the search icon by default.
-
-The `closeResultsOnClick` prop will hide the results when you've clicked on one, which saves screen space on a dense map. Focussing on the search input will show the previous results again (without an extra search).
-
-The `searchBounds` prop takes an array of `[[x1,y1], [x2,y2]]` where these represent the `[sw,ne]` coordinates of the bounding box you want to prioritise search within. Note that in the case of OpenStreetmap at least, this doesn't explicitly exclude results outside the bounding box.  
-
 
 
 ## Info about search input

--- a/README.md
+++ b/README.md
@@ -85,12 +85,17 @@ Other aspects can be customized as well:
   showPopup={false}
   openSearchOnLoad={false}
   closeResultsOnClick={false}
+  searchBounds={[]}
 />
 ```
 
 The `openSearchOnLoad` prop allows you to show the search bar instead of the search icon by default.
 
 The `closeResultsOnClick` prop will hide the results when you've clicked on one, which saves screen space on a dense map. Focussing on the search input will show the previous results again (without an extra search).
+
+The `searchBounds` prop takes an array of `[[x1,y1], [x2,y2]]` where these represent the `[sw,ne]` coordinates of the bounding box you want to prioritise search within. Note that in the case of OpenStreetmap at least, this doesn't explicitly exclude results outside the bounding box.  
+
+
 
 ## Info about search input
 It has two modes:

--- a/examples/components/simple.js
+++ b/examples/components/simple.js
@@ -59,8 +59,9 @@ export default class SimpleExample extends Component {
           popUp={this.customPopup}
           // closeResultsOnClick={false}
           openSearchOnLoad={true}
-          searchBounds={[[51.24988,-0.55343],[51.72617,0.33233]]}
-          providerOptions={{region: 'gb'}}
+          // these searchbounds would limit results to only London.
+          // searchBounds={[[51.24988,-0.55343],[51.72617,0.33233]]}
+          // providerOptions={{region: 'gb'}}
 
 
           // default provider OpenStreetMap

--- a/examples/components/simple.js
+++ b/examples/components/simple.js
@@ -58,7 +58,10 @@ export default class SimpleExample extends Component {
           showPopup={true}
           popUp={this.customPopup}
           // closeResultsOnClick={false}
-          // openSearchOnLoad={true}
+          openSearchOnLoad={true}
+          searchBounds={[[51.24988,-0.55343],[51.72617,0.33233]]}
+
+
 
           // default provider OpenStreetMap
           // provider="BingMap"

--- a/examples/components/simple.js
+++ b/examples/components/simple.js
@@ -57,10 +57,10 @@ export default class SimpleExample extends Component {
           showMarker={true}
           showPopup={true}
           popUp={this.customPopup}
-          // closeResultsOnClick={false}
+          closeResultsOnClick={true}
           openSearchOnLoad={true}
           // these searchbounds would limit results to only London.
-          // searchBounds={[[51.24988,-0.55343],[51.72617,0.33233]]}
+          searchBounds={[[51.24988,-0.55343],[51.72617,0.33233]]}
           // providerOptions={{region: 'gb'}}
 
 

--- a/examples/components/simple.js
+++ b/examples/components/simple.js
@@ -46,7 +46,7 @@ export default class SimpleExample extends Component {
     return (
       <Map
           className="simpleMap"
-          scrollWheelZoom={false}
+          scrollWheelZoom={true}
           bounds={this.state.bounds}
           maxZoom={this.state.maxZoom}
           maxBounds={this.state.maxBounds}>

--- a/examples/components/simple.js
+++ b/examples/components/simple.js
@@ -60,7 +60,7 @@ export default class SimpleExample extends Component {
           // closeResultsOnClick={false}
           openSearchOnLoad={true}
           searchBounds={[[51.24988,-0.55343],[51.72617,0.33233]]}
-
+          providerOptions={{region: 'gb'}}
 
 
           // default provider OpenStreetMap

--- a/examples/components/simple.js
+++ b/examples/components/simple.js
@@ -52,12 +52,13 @@ export default class SimpleExample extends Component {
           maxBounds={this.state.maxBounds}>
         <TileLayer noWrap={true} url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" />
         <ReactLeafletSearch
-          position="topleft"
-          search={[56,7]}
+          position="topright"
           inputPlaceholder="Custom placeholder"
           showMarker={true}
           showPopup={true}
           popUp={this.customPopup}
+          // closeResultsOnClick={false}
+          // openSearchOnLoad={true}
 
           // default provider OpenStreetMap
           // provider="BingMap"

--- a/lib/ExtendedMarker.js
+++ b/lib/ExtendedMarker.js
@@ -4,12 +4,36 @@ exports.__esModule = true;
 
 var _reactLeaflet = require('react-leaflet');
 
-class ExtendedMarker extends _reactLeaflet.Marker {
-    componentDidMount(...a) {
-        super.componentDidMount(...a);
-        setTimeout(() => {
-            this.leafletElement.openPopup();
-        }, 1);
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var ExtendedMarker = function (_Marker) {
+    _inherits(ExtendedMarker, _Marker);
+
+    function ExtendedMarker() {
+        _classCallCheck(this, ExtendedMarker);
+
+        return _possibleConstructorReturn(this, _Marker.apply(this, arguments));
     }
-}
+
+    ExtendedMarker.prototype.componentDidMount = function componentDidMount() {
+        var _Marker$prototype$com,
+            _this2 = this;
+
+        for (var _len = arguments.length, a = Array(_len), _key = 0; _key < _len; _key++) {
+            a[_key] = arguments[_key];
+        }
+
+        (_Marker$prototype$com = _Marker.prototype.componentDidMount).call.apply(_Marker$prototype$com, [this].concat(a));
+        setTimeout(function () {
+            _this2.leafletElement.openPopup();
+        }, 1);
+    };
+
+    return ExtendedMarker;
+}(_reactLeaflet.Marker);
+
 exports.default = ExtendedMarker;

--- a/lib/InputBox.js
+++ b/lib/InputBox.js
@@ -191,13 +191,13 @@ class InputBox extends _react2.default.Component {
         if (this.props.provider && Object.keys(_Providers2.default).includes(this.props.provider)) {
             const Provider = _Providers2.default[this.props.provider];
             if (this.props.providerKey) {
-                this.provider = new Provider(this.props.providerKey);
+                this.provider = new Provider({ providerKey: this.props.providerKey, searchBounds: this.props.searchBounds });
             } else {
-                this.provider = new Provider();
+                this.provider = new Provider({ searchBounds: this.props.searchBounds });
             }
         } else {
             const Provider = _Providers2.default.OpenStreetMap;
-            this.provider = new Provider();
+            this.provider = new Provider({ searchBounds: this.props.searchBounds });
         }
         if (this.props.search && Array.isArray(this.props.search) && !isNaN(Number(this.props.search[0])) && !isNaN(Number(this.props.search[1]))) {
             this.input.value = `:${this.props.search.toString()}`;

--- a/lib/InputBox.js
+++ b/lib/InputBox.js
@@ -190,14 +190,9 @@ class InputBox extends _react2.default.Component {
         this.setMaxHeight();
         if (this.props.provider && Object.keys(_Providers2.default).includes(this.props.provider)) {
             const Provider = _Providers2.default[this.props.provider];
-            if (this.props.providerKey) {
-                this.provider = new Provider({ providerKey: this.props.providerKey, searchBounds: this.props.searchBounds });
-            } else {
-                this.provider = new Provider({ searchBounds: this.props.searchBounds });
-            }
+            this.provider = new Provider(Object.assign({ providerKey: this.props.providerKey, searchBounds: this.props.searchBounds }, this.props.providerOptions));
         } else {
-            const Provider = _Providers2.default.OpenStreetMap;
-            this.provider = new Provider({ searchBounds: this.props.searchBounds });
+            throw new Error(`You set the provider prop to ${this.props.provider} but that isn't recognised. You can choose from ${Object.keys(_Providers2.default).join(", ")}`);
         }
         if (this.props.search && Array.isArray(this.props.search) && !isNaN(Number(this.props.search[0])) && !isNaN(Number(this.props.search[1]))) {
             this.input.value = `:${this.props.search.toString()}`;

--- a/lib/InputBox.js
+++ b/lib/InputBox.js
@@ -2,6 +2,8 @@
 
 exports.__esModule = true;
 
+var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
+
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
@@ -12,90 +14,155 @@ var _Providers2 = _interopRequireDefault(_Providers);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-const asyncInputEvent = (asyncHandler, syncHandler) => {
-    let t;
-    return e => {
+function _asyncToGenerator(fn) { return function () { var gen = fn.apply(this, arguments); return new Promise(function (resolve, reject) { function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { return Promise.resolve(value).then(function (value) { step("next", value); }, function (err) { step("throw", err); }); } } return step("next"); }); }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var asyncInputEvent = function asyncInputEvent(asyncHandler, syncHandler) {
+    var t = void 0;
+    return function (e) {
         syncHandler && syncHandler(e);
         clearTimeout(t);
-        t = setTimeout(() => {
+        t = setTimeout(function () {
             asyncHandler(e);
         }, 400);
     };
 };
 
-class InputBox extends _react2.default.Component {
-    constructor(props) {
-        super(props);
-        this.input = null;
-        this.state = {
-            open: this.props.openSearchOnLoad,
+var InputBox = function (_React$Component) {
+    _inherits(InputBox, _React$Component);
+
+    function InputBox(props) {
+        _classCallCheck(this, InputBox);
+
+        var _this = _possibleConstructorReturn(this, _React$Component.call(this, props));
+
+        _this.input = null;
+        _this.state = {
+            open: _this.props.openSearchOnLoad,
             closeButton: false,
             info: false
         };
-        this.provider = null;
-        this.responseCache = {};
-        this.inputEventHandler = asyncInputEvent(this.sendToAction.bind(this), this.syncInput.bind(this));
-        this.lastInfo = null;
+        _this.provider = null;
+        _this.responseCache = {};
+        _this.inputEventHandler = asyncInputEvent(_this.sendToAction.bind(_this), _this.syncInput.bind(_this));
+        _this.lastInfo = null;
+        return _this;
     }
 
-    inputMouseEnter(event) {
+    InputBox.prototype.inputMouseEnter = function inputMouseEnter(event) {
         this.lock = true;
-    }
-    inputMouseLeave(event) {
+    };
+
+    InputBox.prototype.inputMouseLeave = function inputMouseLeave(event) {
         this.lock = false;
-    }
-    aMouseEnter(event) {
+    };
+
+    InputBox.prototype.aMouseEnter = function aMouseEnter(event) {
         this.lock = true;
-    }
-    aMouseLeave(event) {
+    };
+
+    InputBox.prototype.aMouseLeave = function aMouseLeave(event) {
         this.lock = false;
-    }
-    aClick(event) {
+    };
+
+    InputBox.prototype.aClick = function aClick(event) {
         this.state.open ? this.closeSearch() : this.openSearch();
-    }
-    inputBlur(event) {
+    };
+
+    InputBox.prototype.inputBlur = function inputBlur(event) {
         this.input.value === '' && !this.lock && this.closeSearch();
-    }
-    inputClick(event) {
+    };
+
+    InputBox.prototype.inputClick = function inputClick(event) {
         this.input.focus();
         if (this.lastInfo !== null) {
             this.info = this.lastInfo;
             this.lastInfo = null;
             this.setState({ info: true });
         }
-    }
-    inputInput(event) {
-        this.inputEventHandler(event);
-    }
-    inputKeyUp(event) {
-        event.keyCode === 13 && this.beautifyValue(this.input.value);
-    }
-    closeClick(event) {
-        this.closeSearch();
-    }
+    };
 
-    async sendToAction(event) {
-        if (!this.input.value.startsWith(":")) {
-            // console.log(this.input.value, 'ASYNC', this);
-            if (Object.prototype.hasOwnProperty.call(this.responseCache, this.input.value)) {
-                // console.log('from cache');
-                this.showInfo(this.responseCache[this.input.value].info);
-            } else {
-                if (this.input.value.length >= 3) {
-                    // console.log('fetching');
-                    this.showInfo('Searching...');
-                    const response = await this.provider.search(this.input.value);
-                    if (response.error) {
-                        console.error(response.error);return false;
+    InputBox.prototype.inputInput = function inputInput(event) {
+        this.inputEventHandler(event);
+    };
+
+    InputBox.prototype.inputKeyUp = function inputKeyUp(event) {
+        event.keyCode === 13 && this.beautifyValue(this.input.value);
+    };
+
+    InputBox.prototype.closeClick = function closeClick(event) {
+        this.closeSearch();
+    };
+
+    InputBox.prototype.sendToAction = function () {
+        var _ref = _asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee(event) {
+            var response;
+            return regeneratorRuntime.wrap(function _callee$(_context) {
+                while (1) {
+                    switch (_context.prev = _context.next) {
+                        case 0:
+                            if (this.input.value.startsWith(":")) {
+                                _context.next = 15;
+                                break;
+                            }
+
+                            if (!Object.prototype.hasOwnProperty.call(this.responseCache, this.input.value)) {
+                                _context.next = 5;
+                                break;
+                            }
+
+                            // console.log('from cache');
+                            this.showInfo(this.responseCache[this.input.value].info);
+                            _context.next = 15;
+                            break;
+
+                        case 5:
+                            if (!(this.input.value.length >= 3)) {
+                                _context.next = 15;
+                                break;
+                            }
+
+                            // console.log('fetching');
+                            this.showInfo('Searching...');
+                            _context.next = 9;
+                            return this.provider.search(this.input.value);
+
+                        case 9:
+                            response = _context.sent;
+
+                            if (!response.error) {
+                                _context.next = 13;
+                                break;
+                            }
+
+                            console.error(response.error);return _context.abrupt('return', false);
+
+                        case 13:
+                            // console.log(response);
+                            this.responseCache[this.input.value] = response;
+                            this.showInfo(response.info);
+
+                        case 15:
+                        case 'end':
+                            return _context.stop();
                     }
-                    // console.log(response);
-                    this.responseCache[this.input.value] = response;
-                    this.showInfo(response.info);
                 }
-            }
+            }, _callee, this);
+        }));
+
+        function sendToAction(_x) {
+            return _ref.apply(this, arguments);
         }
-    }
-    syncInput(event) {
+
+        return sendToAction;
+    }();
+
+    InputBox.prototype.syncInput = function syncInput(event) {
         !this.state.closeButton && this.setState({ closeButton: true });
         if (this.input.value == '') {
             this.hideInfo();
@@ -104,25 +171,34 @@ class InputBox extends _react2.default.Component {
         if (!this.input.value.startsWith(":")) {
             // console.log(this.input.value);
         }
-    }
+    };
 
-    openSearch() {
-        this.setState({ open: true }, () => {
-            this.input.focus();
-        });
-    }
-    closeSearch() {
-        this.setState({ open: this.props.openSearchOnLoad, closeButton: false, info: false }, () => {
-            this.input.value = '';
-            this.info = '';
-            this.props.removeMarker && this.props.removeMarker();
-        });
-    }
+    InputBox.prototype.openSearch = function openSearch() {
+        var _this2 = this;
 
-    beautifyValue(value) {
+        this.setState({ open: true }, function () {
+            _this2.input.focus();
+        });
+    };
+
+    InputBox.prototype.closeSearch = function closeSearch() {
+        var _this3 = this;
+
+        this.setState({ open: this.props.openSearchOnLoad, closeButton: false, info: false }, function () {
+            _this3.input.value = '';
+            _this3.info = '';
+            _this3.props.removeMarker && _this3.props.removeMarker();
+        });
+    };
+
+    InputBox.prototype.beautifyValue = function beautifyValue(value) {
         // console.log(value);
         if (value.startsWith(":")) {
-            const latLng = value.slice(1).split(',').filter(e => !isNaN(Number(e))).map(e => Number(e ? e : 0));
+            var latLng = value.slice(1).split(',').filter(function (e) {
+                return !isNaN(Number(e));
+            }).map(function (e) {
+                return Number(e ? e : 0);
+            });
             if (latLng.length <= 1) {
                 this.showInfo('Please enter a valid lat, lng');
             } else {
@@ -131,18 +207,21 @@ class InputBox extends _react2.default.Component {
             }
         } else {
             if (this.input.value.length < 3) {
-                const response = 'Please enter a valid lat,lng starting with ":" or minimum 3 character to search';
+                var response = 'Please enter a valid lat,lng starting with ":" or minimum 3 character to search';
                 this.showInfo(response);
             }
         }
-    }
+    };
 
-    hideInfo() {
+    InputBox.prototype.hideInfo = function hideInfo() {
         this.lastInfo = this.info;
         this.info = '';
         this.setState({ info: false });
-    }
-    showInfo(info, activeIndex) {
+    };
+
+    InputBox.prototype.showInfo = function showInfo(info, activeIndex) {
+        var _this4 = this;
+
         if (typeof info === 'string') {
             this.info = _react2.default.createElement(
                 'span',
@@ -150,71 +229,77 @@ class InputBox extends _react2.default.Component {
                 info
             );
         }
-        if (typeof info === 'object') {
+        if ((typeof info === 'undefined' ? 'undefined' : _typeof(info)) === 'object') {
             this.info = _react2.default.createElement(
                 'ul',
                 { className: 'leaflet-search-control-info-ul' },
-                info.map((e, i) => _react2.default.createElement(
-                    'li',
-                    {
-                        key: `${e.name}-${i}`,
-                        className: `leaflet-search-control-info-li${typeof activeIndex !== 'undefined' ? activeIndex === i ? ' active' : '' : ''}`,
-                        onClick: this.listItemClick.bind(this, e, info, i) },
-                    _react2.default.createElement(
-                        'p',
-                        null,
-                        e.name
-                    )
-                ))
+                info.map(function (e, i) {
+                    return _react2.default.createElement(
+                        'li',
+                        {
+                            key: e.name + '-' + i,
+                            className: 'leaflet-search-control-info-li' + (typeof activeIndex !== 'undefined' ? activeIndex === i ? ' active' : '' : ''),
+                            onClick: _this4.listItemClick.bind(_this4, e, info, i) },
+                        _react2.default.createElement(
+                            'p',
+                            null,
+                            e.name
+                        )
+                    );
+                })
             );
         }
         this.input.value && this.setState({ info: true });
-    }
+    };
 
-    listItemClick(itemData, totalInfo, activeIndex, event) {
+    InputBox.prototype.listItemClick = function listItemClick(itemData, totalInfo, activeIndex, event) {
         this.showInfo(totalInfo, activeIndex);
         this.props.latLngHandler([Number(itemData.latitude), Number(itemData.longitude)], itemData.name);
         if (this.props.closeResultsOnClick) {
             this.hideInfo();
         }
-    }
+    };
 
-    setMaxHeight() {
-        const containerRect = this.props.map.getContainer().getBoundingClientRect();
-        const divRect = this.input.getBoundingClientRect();
-        const maxHeight = `${Math.floor((containerRect.bottom - divRect.bottom - 10) * 0.95)}px`;
+    InputBox.prototype.setMaxHeight = function setMaxHeight() {
+        var containerRect = this.props.map.getContainer().getBoundingClientRect();
+        var divRect = this.input.getBoundingClientRect();
+        var maxHeight = Math.floor((containerRect.bottom - divRect.bottom - 10) * 0.95) + 'px';
         this.div.style.maxHeight = maxHeight;
-    }
+    };
 
-    componentDidMount() {
+    InputBox.prototype.componentDidMount = function componentDidMount() {
         this.setMaxHeight();
         if (this.props.provider && Object.keys(_Providers2.default).includes(this.props.provider)) {
-            const Provider = _Providers2.default[this.props.provider];
+            var Provider = _Providers2.default[this.props.provider];
             this.provider = new Provider(Object.assign({ providerKey: this.props.providerKey, searchBounds: this.props.searchBounds }, this.props.providerOptions));
         } else {
-            throw new Error(`You set the provider prop to ${this.props.provider} but that isn't recognised. You can choose from ${Object.keys(_Providers2.default).join(", ")}`);
+            throw new Error('You set the provider prop to ' + this.props.provider + ' but that isn\'t recognised. You can choose from ' + Object.keys(_Providers2.default).join(", "));
         }
         if (this.props.search && Array.isArray(this.props.search) && !isNaN(Number(this.props.search[0])) && !isNaN(Number(this.props.search[1]))) {
-            this.input.value = `:${this.props.search.toString()}`;
+            this.input.value = ':' + this.props.search.toString();
             this.openSearch();
             this.syncInput(); // to show close button
             this.props.latLngHandler([Number(this.props.search[0]), Number(this.props.search[1])], this.props.search.toString());
         }
-    }
+    };
 
-    render() {
+    InputBox.prototype.render = function render() {
+        var _this5 = this;
+
         return _react2.default.createElement(
             'div',
-            { className: `leaflet-search-control leaflet-bar-part leaflet-bar${this.state.open && ' leaflet-search-control-active'}` },
+            { className: 'leaflet-search-control leaflet-bar-part leaflet-bar' + (this.state.open && ' leaflet-search-control-active') },
             _react2.default.createElement('a', {
-                className: `leaflet-search-control-a leaflet-search-icon`,
+                className: 'leaflet-search-control-a leaflet-search-icon',
                 onClick: this.aClick.bind(this),
                 onMouseEnter: this.aMouseEnter.bind(this),
                 onMouseLeave: this.aMouseLeave.bind(this)
                 // onMouseDown={this.aMouseDown.bind(this)}
             }),
             _react2.default.createElement('input', {
-                ref: ref => this.input = ref,
+                ref: function ref(_ref2) {
+                    return _this5.input = _ref2;
+                },
                 className: 'leaflet-search-control-input leaflet-search-input',
                 placeholder: this.props.inputPlaceholder,
                 onClick: this.inputClick.bind(this)
@@ -227,18 +312,23 @@ class InputBox extends _react2.default.Component {
             _react2.default.createElement(
                 'div',
                 {
-                    className: `leaflet-search-control-close${this.state.closeButton ? ' leaflet-search-close' : ''}`,
+                    className: 'leaflet-search-control-close' + (this.state.closeButton ? ' leaflet-search-close' : ''),
                     onClick: this.closeClick.bind(this) },
                 'x'
             ),
             _react2.default.createElement(
                 'div',
                 {
-                    ref: ref => this.div = ref,
-                    className: `leaflet-search-control-info${this.state.info ? '' : ' close'}` },
+                    ref: function ref(_ref3) {
+                        return _this5.div = _ref3;
+                    },
+                    className: 'leaflet-search-control-info' + (this.state.info ? '' : ' close') },
                 this.state.info && this.info
             )
         );
-    }
-}
+    };
+
+    return InputBox;
+}(_react2.default.Component);
+
 exports.default = InputBox;

--- a/lib/InputBox.js
+++ b/lib/InputBox.js
@@ -12,8 +12,6 @@ var _Providers2 = _interopRequireDefault(_Providers);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-function _asyncToGenerator(fn) { return function () { var gen = fn.apply(this, arguments); return new Promise(function (resolve, reject) { function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { return Promise.resolve(value).then(function (value) { step("next", value); }, function (err) { step("throw", err); }); } } return step("next"); }); }; }
-
 const asyncInputEvent = (asyncHandler, syncHandler) => {
     let t;
     return e => {
@@ -30,13 +28,14 @@ class InputBox extends _react2.default.Component {
         super(props);
         this.input = null;
         this.state = {
-            open: false,
+            open: this.props.openSearchOnLoad,
             closeButton: false,
             info: false
         };
         this.provider = null;
         this.responseCache = {};
         this.inputEventHandler = asyncInputEvent(this.sendToAction.bind(this), this.syncInput.bind(this));
+        this.lastInfo = null;
     }
 
     inputMouseEnter(event) {
@@ -59,6 +58,11 @@ class InputBox extends _react2.default.Component {
     }
     inputClick(event) {
         this.input.focus();
+        if (this.lastInfo !== null) {
+            this.info = this.lastInfo;
+            this.lastInfo = null;
+            this.setState({ info: true });
+        }
     }
     inputInput(event) {
         this.inputEventHandler(event);
@@ -70,30 +74,26 @@ class InputBox extends _react2.default.Component {
         this.closeSearch();
     }
 
-    sendToAction(event) {
-        var _this = this;
-
-        return _asyncToGenerator(function* () {
-            if (!_this.input.value.startsWith(":")) {
-                // console.log(this.input.value, 'ASYNC', this);
-                if (Object.prototype.hasOwnProperty.call(_this.responseCache, _this.input.value)) {
-                    // console.log('from cache');
-                    _this.showInfo(_this.responseCache[_this.input.value].info);
-                } else {
-                    if (_this.input.value.length >= 3) {
-                        // console.log('fetching');
-                        _this.showInfo('Searching...');
-                        const response = yield _this.provider.search(_this.input.value);
-                        if (response.error) {
-                            console.error(response.error);return false;
-                        }
-                        // console.log(response);
-                        _this.responseCache[_this.input.value] = response;
-                        _this.showInfo(response.info);
+    async sendToAction(event) {
+        if (!this.input.value.startsWith(":")) {
+            // console.log(this.input.value, 'ASYNC', this);
+            if (Object.prototype.hasOwnProperty.call(this.responseCache, this.input.value)) {
+                // console.log('from cache');
+                this.showInfo(this.responseCache[this.input.value].info);
+            } else {
+                if (this.input.value.length >= 3) {
+                    // console.log('fetching');
+                    this.showInfo('Searching...');
+                    const response = await this.provider.search(this.input.value);
+                    if (response.error) {
+                        console.error(response.error);return false;
                     }
+                    // console.log(response);
+                    this.responseCache[this.input.value] = response;
+                    this.showInfo(response.info);
                 }
             }
-        })();
+        }
     }
     syncInput(event) {
         !this.state.closeButton && this.setState({ closeButton: true });
@@ -112,7 +112,7 @@ class InputBox extends _react2.default.Component {
         });
     }
     closeSearch() {
-        this.setState({ open: false, closeButton: false, info: false }, () => {
+        this.setState({ open: this.props.openSearchOnLoad, closeButton: false, info: false }, () => {
             this.input.value = '';
             this.info = '';
             this.props.removeMarker && this.props.removeMarker();
@@ -138,6 +138,7 @@ class InputBox extends _react2.default.Component {
     }
 
     hideInfo() {
+        this.lastInfo = this.info;
         this.info = '';
         this.setState({ info: false });
     }
@@ -158,7 +159,7 @@ class InputBox extends _react2.default.Component {
                     {
                         key: `${e.name}-${i}`,
                         className: `leaflet-search-control-info-li${typeof activeIndex !== 'undefined' ? activeIndex === i ? ' active' : '' : ''}`,
-                        onClick: this.lisItemClick.bind(this, e, info, i) },
+                        onClick: this.listItemClick.bind(this, e, info, i) },
                     _react2.default.createElement(
                         'p',
                         null,
@@ -170,9 +171,12 @@ class InputBox extends _react2.default.Component {
         this.input.value && this.setState({ info: true });
     }
 
-    lisItemClick(itemData, totalInfo, activeIndex, event) {
+    listItemClick(itemData, totalInfo, activeIndex, event) {
         this.showInfo(totalInfo, activeIndex);
         this.props.latLngHandler([Number(itemData.latitude), Number(itemData.longitude)], itemData.name);
+        if (this.props.closeResultsOnClick) {
+            this.hideInfo();
+        }
     }
 
     setMaxHeight() {

--- a/lib/Providers/BingMap.js
+++ b/lib/Providers/BingMap.js
@@ -2,12 +2,13 @@
 
 exports.__esModule = true;
 class BingMap {
-  constructor({ providerKey = null, searchBounds = [] } = {}) {
-    this.key = providerkey;
+  constructor(options = { providerKey: null, searchBounds: [] }) {
+    let { providerKey, searchBounds } = options;
+    this.key = providerKey;
     //Bounds are expected to be a nested array of [[sw_lat, sw_lng],[ne_lat, ne_lng]].
     // We convert them into a string of 'x1,y1,x2,y2'
     let boundsUrlComponent = "";
-    if (searchbounds !== []) {
+    if (searchBounds.length) {
       this.bounds = [].concat([], ...searchBounds).join(",");
       boundsUrlComponent = `&umv=${this.bounds}`;
     }

--- a/lib/Providers/BingMap.js
+++ b/lib/Providers/BingMap.js
@@ -1,46 +1,94 @@
 "use strict";
 
 exports.__esModule = true;
-class BingMap {
-  constructor(options = { providerKey: null, searchBounds: [] }) {
-    let { providerKey, searchBounds } = options;
+
+function _asyncToGenerator(fn) { return function () { var gen = fn.apply(this, arguments); return new Promise(function (resolve, reject) { function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { return Promise.resolve(value).then(function (value) { step("next", value); }, function (err) { step("throw", err); }); } } return step("next"); }); }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+var BingMap = function () {
+  function BingMap() {
+    var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : { providerKey: null, searchBounds: [] };
+
+    _classCallCheck(this, BingMap);
+
+    var providerKey = options.providerKey,
+        searchBounds = options.searchBounds;
+
     this.key = providerKey;
     //Bounds are expected to be a nested array of [[sw_lat, sw_lng],[ne_lat, ne_lng]].
     // We convert them into a string of 'x1,y1,x2,y2'
-    let boundsUrlComponent = "";
+    var boundsUrlComponent = "";
     if (searchBounds.length) {
-      this.bounds = [].concat([], ...searchBounds).join(",");
-      boundsUrlComponent = `&umv=${this.bounds}`;
+      var _ref;
+
+      this.bounds = (_ref = []).concat.apply(_ref, [[]].concat(searchBounds)).join(",");
+      boundsUrlComponent = "&umv=" + this.bounds;
     }
-    this.url = `https://dev.virtualearth.net/REST/v1/Locations?output=json${boundsUrlComponent}&key=${this.key}&q=`;
+    this.url = "https://dev.virtualearth.net/REST/v1/Locations?output=json" + boundsUrlComponent + "&key=" + this.key + "&q=";
   }
 
-  async search(query) {
-    if (typeof this.key === 'undefined') {
-      return { error: 'BingMap requires an api key' };
-    }
-    // console.log(this.url + query)
-    const response = await fetch(this.url + query).then(res => res.json());
-    return this.formatResponse(response);
-  }
+  BingMap.prototype.search = function () {
+    var _ref2 = _asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee(query) {
+      var response;
+      return regeneratorRuntime.wrap(function _callee$(_context) {
+        while (1) {
+          switch (_context.prev = _context.next) {
+            case 0:
+              if (!(typeof this.key === 'undefined')) {
+                _context.next = 2;
+                break;
+              }
 
-  formatResponse(response) {
+              return _context.abrupt("return", { error: 'BingMap requires an api key' });
+
+            case 2:
+              _context.next = 4;
+              return fetch(this.url + query).then(function (res) {
+                return res.json();
+              });
+
+            case 4:
+              response = _context.sent;
+              return _context.abrupt("return", this.formatResponse(response));
+
+            case 6:
+            case "end":
+              return _context.stop();
+          }
+        }
+      }, _callee, this);
+    }));
+
+    function search(_x2) {
+      return _ref2.apply(this, arguments);
+    }
+
+    return search;
+  }();
+
+  BingMap.prototype.formatResponse = function formatResponse(response) {
     // console.log(response)
-    const resources = response.resourceSets[0].resources;
-    const count = response.resourceSets[0].estimatedTotal;
+    var resources = response.resourceSets[0].resources;
+    var count = response.resourceSets[0].estimatedTotal;
     // console.log(resources)
-    const info = count > 0 ? resources.map(e => ({
-      bounds: e.bbox.map(bound => Number(bound)),
-      latitude: Number(e.point.coordinates[0]),
-      longitude: Number(e.point.coordinates[1]),
-      name: e.name
-    })) : 'Not Found';
+    var info = count > 0 ? resources.map(function (e) {
+      return {
+        bounds: e.bbox.map(function (bound) {
+          return Number(bound);
+        }),
+        latitude: Number(e.point.coordinates[0]),
+        longitude: Number(e.point.coordinates[1]),
+        name: e.name
+      };
+    }) : 'Not Found';
     return {
       info: info,
       raw: response
     };
-  }
+  };
 
-}
+  return BingMap;
+}();
 
 exports.BingMap = BingMap;

--- a/lib/Providers/BingMap.js
+++ b/lib/Providers/BingMap.js
@@ -1,10 +1,17 @@
-'use strict';
+"use strict";
 
 exports.__esModule = true;
 class BingMap {
-  constructor(providerkey) {
+  constructor({ providerKey = null, searchBounds = [] } = {}) {
     this.key = providerkey;
-    this.url = `https://dev.virtualearth.net/REST/v1/Locations?output=json&key=${this.key}&q=`;
+    //Bounds are expected to be a nested array of [[sw_lat, sw_lng],[ne_lat, ne_lng]].
+    // We convert them into a string of 'x1,y1,x2,y2'
+    let boundsUrlComponent = "";
+    if (searchbounds !== []) {
+      this.bounds = [].concat([], ...searchBounds).join(",");
+      boundsUrlComponent = `&umv=${this.bounds}`;
+    }
+    this.url = `https://dev.virtualearth.net/REST/v1/Locations?output=json${boundsUrlComponent}&key=${this.key}&q=`;
   }
 
   async search(query) {

--- a/lib/Providers/BingMap.js
+++ b/lib/Providers/BingMap.js
@@ -1,28 +1,19 @@
 'use strict';
 
 exports.__esModule = true;
-
-function _asyncToGenerator(fn) { return function () { var gen = fn.apply(this, arguments); return new Promise(function (resolve, reject) { function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { return Promise.resolve(value).then(function (value) { step("next", value); }, function (err) { step("throw", err); }); } } return step("next"); }); }; }
-
 class BingMap {
   constructor(providerkey) {
     this.key = providerkey;
     this.url = `https://dev.virtualearth.net/REST/v1/Locations?output=json&key=${this.key}&q=`;
   }
 
-  search(query) {
-    var _this = this;
-
-    return _asyncToGenerator(function* () {
-      if (typeof _this.key === 'undefined') {
-        return { error: 'BingMap requires an api key' };
-      }
-      // console.log(this.url + query)
-      const response = yield fetch(_this.url + query).then(function (res) {
-        return res.json();
-      });
-      return _this.formatResponse(response);
-    })();
+  async search(query) {
+    if (typeof this.key === 'undefined') {
+      return { error: 'BingMap requires an api key' };
+    }
+    // console.log(this.url + query)
+    const response = await fetch(this.url + query).then(res => res.json());
+    return this.formatResponse(response);
   }
 
   formatResponse(response) {

--- a/lib/Providers/OpenStreetMap.js
+++ b/lib/Providers/OpenStreetMap.js
@@ -1,9 +1,16 @@
-'use strict';
+"use strict";
 
 exports.__esModule = true;
 class OpenStreetMap {
-  constructor() {
-    this.url = 'https://nominatim.openstreetmap.org/search?format=json&addressdetails=1&polygon_svg=1&namedetails=1&q=';
+  constructor({ providerKey = null, searchBounds = [] } = {}) {
+    //Bounds are expected to be a nested array of [[sw_lat, sw_lng],[ne_lat, ne_lng]].
+    // We convert them into a string of 'x1,y1,x2,y2'
+    let boundsUrlComponent = "";
+    if (searchBounds.length) {
+      this.bounds = [].concat([], ...searchBounds).join(",");
+      boundsUrlComponent = `&viewbox=${this.bounds}`;
+    }
+    this.url = `https://nominatim.openstreetmap.org/search?format=json&addressdetails=1&polygon_svg=1&namedetails=1${boundsUrlComponent}&q=`;
   }
 
   async search(query) {

--- a/lib/Providers/OpenStreetMap.js
+++ b/lib/Providers/OpenStreetMap.js
@@ -1,47 +1,90 @@
 "use strict";
 
 exports.__esModule = true;
-class OpenStreetMap {
-  constructor(options = { providerKey: null, searchBounds: [] }) {
-    let { providerKey, searchBounds } = options;
+
+function _asyncToGenerator(fn) { return function () { var gen = fn.apply(this, arguments); return new Promise(function (resolve, reject) { function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { return Promise.resolve(value).then(function (value) { step("next", value); }, function (err) { step("throw", err); }); } } return step("next"); }); }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+var OpenStreetMap = function () {
+  function OpenStreetMap() {
+    var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : { providerKey: null, searchBounds: [] };
+
+    _classCallCheck(this, OpenStreetMap);
+
+    var providerKey = options.providerKey,
+        searchBounds = options.searchBounds;
     //Bounds are expected to be a nested array of [[sw_lat, sw_lng],[ne_lat, ne_lng]].
     // We convert them into a string of 'x1,y1,x2,y2' which is the opposite way around from lat/lng - it's lng/lat
-    let boundsUrlComponent = "";
-    let regionUrlComponent = "";
+
+    var boundsUrlComponent = "";
+    var regionUrlComponent = "";
     if (searchBounds.length) {
-      const reversed = searchBounds.map(el => {
+      var _ref;
+
+      var reversed = searchBounds.map(function (el) {
         return el.reverse();
       });
-      this.bounds = [].concat([], ...reversed).join(",");
-      boundsUrlComponent = `&bounded=1&viewbox=${this.bounds}`;
+      this.bounds = (_ref = []).concat.apply(_ref, [[]].concat(reversed)).join(",");
+      boundsUrlComponent = "&bounded=1&viewbox=" + this.bounds;
     }
     if ('region' in options) {
-      regionUrlComponent = `&countrycodes=${options.region}`;
+      regionUrlComponent = "&countrycodes=" + options.region;
     }
-    this.url = `https://nominatim.openstreetmap.org/search?format=json&addressdetails=1&polygon_svg=1&namedetails=1${boundsUrlComponent}${regionUrlComponent}&q=`;
+    this.url = "https://nominatim.openstreetmap.org/search?format=json&addressdetails=1&polygon_svg=1&namedetails=1" + boundsUrlComponent + regionUrlComponent + "&q=";
   }
 
-  async search(query) {
-    // console.log(this.url + query)
-    const response = await fetch(this.url + query).then(res => res.json());
-    return this.formatResponse(response);
-  }
+  OpenStreetMap.prototype.search = function () {
+    var _ref2 = _asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee(query) {
+      var response;
+      return regeneratorRuntime.wrap(function _callee$(_context) {
+        while (1) {
+          switch (_context.prev = _context.next) {
+            case 0:
+              _context.next = 2;
+              return fetch(this.url + query).then(function (res) {
+                return res.json();
+              });
 
-  formatResponse(response) {
-    const resources = response;
-    const count = response.length;
-    const info = count > 0 ? resources.map(e => ({
-      bounds: e.boundingbox.map(bound => Number(bound)),
-      latitude: Number(e.lat),
-      longitude: Number(e.lon),
-      name: e.display_name
-    })) : 'Not Found';
+            case 2:
+              response = _context.sent;
+              return _context.abrupt("return", this.formatResponse(response));
+
+            case 4:
+            case "end":
+              return _context.stop();
+          }
+        }
+      }, _callee, this);
+    }));
+
+    function search(_x2) {
+      return _ref2.apply(this, arguments);
+    }
+
+    return search;
+  }();
+
+  OpenStreetMap.prototype.formatResponse = function formatResponse(response) {
+    var resources = response;
+    var count = response.length;
+    var info = count > 0 ? resources.map(function (e) {
+      return {
+        bounds: e.boundingbox.map(function (bound) {
+          return Number(bound);
+        }),
+        latitude: Number(e.lat),
+        longitude: Number(e.lon),
+        name: e.display_name
+      };
+    }) : 'Not Found';
     return {
       info: info,
       raw: response
     };
-  }
+  };
 
-}
+  return OpenStreetMap;
+}();
 
 exports.OpenStreetMap = OpenStreetMap;

--- a/lib/Providers/OpenStreetMap.js
+++ b/lib/Providers/OpenStreetMap.js
@@ -5,12 +5,15 @@ class OpenStreetMap {
   constructor(options = { providerKey: null, searchBounds: [] }) {
     let { providerKey, searchBounds } = options;
     //Bounds are expected to be a nested array of [[sw_lat, sw_lng],[ne_lat, ne_lng]].
-    // We convert them into a string of 'x1,y1,x2,y2'
+    // We convert them into a string of 'x1,y1,x2,y2' which is the opposite way around from lat/lng - it's lng/lat
     let boundsUrlComponent = "";
     let regionUrlComponent = "";
     if (searchBounds.length) {
-      this.bounds = [].concat([], ...searchBounds).join(",");
-      boundsUrlComponent = `&viewbox=${this.bounds}`;
+      const reversed = searchBounds.map(el => {
+        return el.reverse();
+      });
+      this.bounds = [].concat([], ...reversed).join(",");
+      boundsUrlComponent = `&bounded=1&viewbox=${this.bounds}`;
     }
     if ('region' in options) {
       regionUrlComponent = `&countrycodes=${options.region}`;

--- a/lib/Providers/OpenStreetMap.js
+++ b/lib/Providers/OpenStreetMap.js
@@ -2,15 +2,20 @@
 
 exports.__esModule = true;
 class OpenStreetMap {
-  constructor({ providerKey = null, searchBounds = [] } = {}) {
+  constructor(options = { providerKey: null, searchBounds: [] }) {
+    let { providerKey, searchBounds } = options;
     //Bounds are expected to be a nested array of [[sw_lat, sw_lng],[ne_lat, ne_lng]].
     // We convert them into a string of 'x1,y1,x2,y2'
     let boundsUrlComponent = "";
+    let regionUrlComponent = "";
     if (searchBounds.length) {
       this.bounds = [].concat([], ...searchBounds).join(",");
       boundsUrlComponent = `&viewbox=${this.bounds}`;
     }
-    this.url = `https://nominatim.openstreetmap.org/search?format=json&addressdetails=1&polygon_svg=1&namedetails=1${boundsUrlComponent}&q=`;
+    if ('region' in options) {
+      regionUrlComponent = `&countrycodes=${options.region}`;
+    }
+    this.url = `https://nominatim.openstreetmap.org/search?format=json&addressdetails=1&polygon_svg=1&namedetails=1${boundsUrlComponent}${regionUrlComponent}&q=`;
   }
 
   async search(query) {

--- a/lib/Providers/OpenStreetMap.js
+++ b/lib/Providers/OpenStreetMap.js
@@ -1,24 +1,15 @@
 'use strict';
 
 exports.__esModule = true;
-
-function _asyncToGenerator(fn) { return function () { var gen = fn.apply(this, arguments); return new Promise(function (resolve, reject) { function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { return Promise.resolve(value).then(function (value) { step("next", value); }, function (err) { step("throw", err); }); } } return step("next"); }); }; }
-
 class OpenStreetMap {
   constructor() {
     this.url = 'https://nominatim.openstreetmap.org/search?format=json&addressdetails=1&polygon_svg=1&namedetails=1&q=';
   }
 
-  search(query) {
-    var _this = this;
-
-    return _asyncToGenerator(function* () {
-      // console.log(this.url + query)
-      const response = yield fetch(_this.url + query).then(function (res) {
-        return res.json();
-      });
-      return _this.formatResponse(response);
-    })();
+  async search(query) {
+    // console.log(this.url + query)
+    const response = await fetch(this.url + query).then(res => res.json());
+    return this.formatResponse(response);
   }
 
   formatResponse(response) {

--- a/lib/React-Leaflet-Search.js
+++ b/lib/React-Leaflet-Search.js
@@ -143,11 +143,15 @@ ReactLeafletSearch.propTypes = {
     inputPlaceholder: _propTypes2.default.string,
     showMarker: _propTypes2.default.bool,
     showPopup: _propTypes2.default.bool,
-    popUp: _propTypes2.default.func
+    popUp: _propTypes2.default.func,
+    closeResultsOnClick: _propTypes2.default.bool,
+    openSearchOnLoad: _propTypes2.default.bool
 };
 
 ReactLeafletSearch.defaultProps = {
     inputPlaceholder: "Search Lat,Lng",
     showMarker: true,
-    showPopup: false
+    showPopup: false,
+    closeResultsOnClick: false,
+    openSearchOnLoad: false
 };

--- a/lib/React-Leaflet-Search.js
+++ b/lib/React-Leaflet-Search.js
@@ -6,6 +6,8 @@ var _ReactLeafletSearch$p;
 
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
+require('babel-polyfill');
+
 require('./react-leaflet-search.css');
 
 var _leaflet = require('leaflet');

--- a/lib/React-Leaflet-Search.js
+++ b/lib/React-Leaflet-Search.js
@@ -2,6 +2,8 @@
 
 exports.__esModule = true;
 
+var _ReactLeafletSearch$p;
+
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
 require('./react-leaflet-search.css');
@@ -28,15 +30,26 @@ var _InputBox2 = _interopRequireDefault(_InputBox);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-class ReactLeafletSearch extends _reactLeaflet.MapControl {
-    constructor(props, context) {
-        super(props);
-        this.div = _leaflet.DomUtil.create('div', 'leaflet-search-wrap');
-        this.state = {
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var ReactLeafletSearch = function (_MapControl) {
+    _inherits(ReactLeafletSearch, _MapControl);
+
+    function ReactLeafletSearch(props, context) {
+        _classCallCheck(this, ReactLeafletSearch);
+
+        var _this = _possibleConstructorReturn(this, _MapControl.call(this, props));
+
+        _this.div = _leaflet.DomUtil.create('div', 'leaflet-search-wrap');
+        _this.state = {
             search: false,
             info: false
         };
-        this.markerIcon = (0, _leaflet.icon)({
+        _this.markerIcon = (0, _leaflet.icon)({
             iconUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.3.1/images/marker-icon.png',
             iconRetinaUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.3.1/images/marker-icon-2x.png',
             shadowUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.3.1/images/marker-shadow.png',
@@ -46,21 +59,26 @@ class ReactLeafletSearch extends _reactLeaflet.MapControl {
             tooltipAnchor: [16, -28],
             shadowSize: [41, 41]
         });
-        this.SearchInfo = null; // searched lat,lng or response from provider
-        this.map = context.map || props.leaflet.map;
+        _this.SearchInfo = null; // searched lat,lng or response from provider
+        _this.map = context.map || props.leaflet.map;
+        return _this;
     }
 
-    createLeafletElement(props) {
-        const ReactLeafletSearch = _leaflet.Control.extend({
-            onAdd: map => this.div,
-            onRemove: map => {}
+    ReactLeafletSearch.prototype.createLeafletElement = function createLeafletElement(props) {
+        var _this2 = this;
+
+        var ReactLeafletSearch = _leaflet.Control.extend({
+            onAdd: function onAdd(map) {
+                return _this2.div;
+            },
+            onRemove: function onRemove(map) {}
         });
         return new ReactLeafletSearch(props);
-    }
+    };
 
-    latLngHandler(latLng, info) {
+    ReactLeafletSearch.prototype.latLngHandler = function latLngHandler(latLng, info) {
         this.SearchInfo = info;
-        const popUpStructure = _react2.default.createElement(
+        var popUpStructure = _react2.default.createElement(
             'div',
             null,
             _react2.default.createElement(
@@ -72,43 +90,46 @@ class ReactLeafletSearch extends _reactLeaflet.MapControl {
             _react2.default.createElement(
                 'div',
                 null,
-                `latitude: ${latLng[0]}`
+                'latitude: ' + latLng[0]
             ),
             _react2.default.createElement(
                 'div',
                 null,
-                `longitude: ${latLng[1]}`
+                'longitude: ' + latLng[1]
             )
         );
         this.goToLatLng(latLng, popUpStructure);
-    }
+    };
 
-    removeMarkerHandler() {
+    ReactLeafletSearch.prototype.removeMarkerHandler = function removeMarkerHandler() {
         this.setState({ search: false });
-    }
+    };
 
-    goToLatLng(latLng, info) {
-        this.setState({ search: latLng, info: info }, () => {
-            this.flyTo();
+    ReactLeafletSearch.prototype.goToLatLng = function goToLatLng(latLng, info) {
+        var _this3 = this;
+
+        this.setState({ search: latLng, info: info }, function () {
+            _this3.flyTo();
         });
-    }
-    flyTo() {
-        this.map.flyTo([...this.state.search], this.props.zoom || 10);
-    }
+    };
 
-    componentDidMount() {
-        super.componentDidMount();
+    ReactLeafletSearch.prototype.flyTo = function flyTo() {
+        this.map.flyTo([].concat(this.state.search), this.props.zoom || 10);
+    };
+
+    ReactLeafletSearch.prototype.componentDidMount = function componentDidMount() {
+        _MapControl.prototype.componentDidMount.call(this);
         _reactDom2.default.render(_react2.default.createElement(_InputBox2.default, _extends({}, this.props, {
             map: this.map,
             latLngHandler: this.latLngHandler.bind(this),
             removeMarker: this.removeMarkerHandler.bind(this) })), this.div);
-    }
+    };
 
-    componentDidUpdate() {
+    ReactLeafletSearch.prototype.componentDidUpdate = function componentDidUpdate() {
         this.markerRef && this.markerRef.leafletElement.openPopup();
-    }
+    };
 
-    defaultPopUp() {
+    ReactLeafletSearch.prototype.defaultPopUp = function defaultPopUp() {
         return _react2.default.createElement(
             _reactLeaflet.Popup,
             null,
@@ -118,25 +139,33 @@ class ReactLeafletSearch extends _reactLeaflet.MapControl {
                 this.state.info
             )
         );
-    }
+    };
 
-    render() {
+    ReactLeafletSearch.prototype.render = function render() {
+        var _this4 = this;
+
         this.markerRef = false;
-        const _ = this;
+        var _ = this;
         return this.state.search && this.props.showMarker ? _react2.default.createElement(
             _reactLeaflet.Marker,
             {
-                ref: ref => this.markerRef = ref,
+                ref: function ref(_ref) {
+                    return _this4.markerRef = _ref;
+                },
                 icon: this.props.markerIcon || this.markerIcon,
-                key: `marker-search-${this.state.search.toString()}`,
-                position: [...this.state.search] },
+                key: 'marker-search-' + this.state.search.toString(),
+                position: [].concat(this.state.search) },
             this.props.showPopup && (this.props.popUp ? this.props.popUp(this.SearchInfo) : this.defaultPopUp())
         ) : null;
-    }
-}
+    };
+
+    return ReactLeafletSearch;
+}(_reactLeaflet.MapControl);
 
 exports.default = ReactLeafletSearch;
-ReactLeafletSearch.propTypes = {
+
+
+ReactLeafletSearch.propTypes = (_ReactLeafletSearch$p = {
     position: _propTypes2.default.string.isRequired,
     provider: _propTypes2.default.string,
     providerKey: _propTypes2.default.string,
@@ -147,10 +176,8 @@ ReactLeafletSearch.propTypes = {
     closeResultsOnClick: _propTypes2.default.bool,
     openSearchOnLoad: _propTypes2.default.bool,
     searchBounds: _propTypes2.default.array,
-    region: _propTypes2.default.string,
-    provider: _propTypes2.default.string,
-    providerOptions: _propTypes2.default.object
-};
+    region: _propTypes2.default.string
+}, _ReactLeafletSearch$p['provider'] = _propTypes2.default.string, _ReactLeafletSearch$p.providerOptions = _propTypes2.default.object, _ReactLeafletSearch$p);
 
 ReactLeafletSearch.defaultProps = {
     inputPlaceholder: "Search Lat,Lng",

--- a/lib/React-Leaflet-Search.js
+++ b/lib/React-Leaflet-Search.js
@@ -47,6 +47,8 @@ var ReactLeafletSearch = function (_MapControl) {
         var _this = _possibleConstructorReturn(this, _MapControl.call(this, props));
 
         _this.div = _leaflet.DomUtil.create('div', 'leaflet-search-wrap');
+        L.DomEvent.disableClickPropagation(_this.div);
+        L.DomEvent.disableScrollPropagation(_this.div);
         _this.state = {
             search: false,
             info: false

--- a/lib/React-Leaflet-Search.js
+++ b/lib/React-Leaflet-Search.js
@@ -146,7 +146,10 @@ ReactLeafletSearch.propTypes = {
     popUp: _propTypes2.default.func,
     closeResultsOnClick: _propTypes2.default.bool,
     openSearchOnLoad: _propTypes2.default.bool,
-    searchBounds: _propTypes2.default.array
+    searchBounds: _propTypes2.default.array,
+    region: _propTypes2.default.string,
+    provider: _propTypes2.default.string,
+    providerOptions: _propTypes2.default.object
 };
 
 ReactLeafletSearch.defaultProps = {
@@ -155,5 +158,8 @@ ReactLeafletSearch.defaultProps = {
     showPopup: false,
     closeResultsOnClick: false,
     openSearchOnLoad: false,
-    searchBounds: []
+    searchBounds: [],
+    region: '',
+    provider: 'OpenStreetMap',
+    providerOptions: {}
 };

--- a/lib/React-Leaflet-Search.js
+++ b/lib/React-Leaflet-Search.js
@@ -145,7 +145,8 @@ ReactLeafletSearch.propTypes = {
     showPopup: _propTypes2.default.bool,
     popUp: _propTypes2.default.func,
     closeResultsOnClick: _propTypes2.default.bool,
-    openSearchOnLoad: _propTypes2.default.bool
+    openSearchOnLoad: _propTypes2.default.bool,
+    searchBounds: _propTypes2.default.array
 };
 
 ReactLeafletSearch.defaultProps = {
@@ -153,5 +154,6 @@ ReactLeafletSearch.defaultProps = {
     showMarker: true,
     showPopup: false,
     closeResultsOnClick: false,
-    openSearchOnLoad: false
+    openSearchOnLoad: false,
+    searchBounds: []
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,7 +6,7 @@ var _ReactLeafletSearch = require('./React-Leaflet-Search');
 
 Object.defineProperty(exports, 'ReactLeafletSearch', {
   enumerable: true,
-  get: function () {
+  get: function get() {
     return _interopRequireDefault(_ReactLeafletSearch).default;
   }
 });

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-env": "^1.7.0",
     "babel-preset-react": "^6.24.1",
+    "babel-polyfill": "^6.26.0",
     "css-loader": "^1.0.0",
     "leaflet": "^1.3.3",
     "mini-css-extract-plugin": "^0.4.1",
@@ -41,6 +42,5 @@
     "webpack": "^4.16.3",
     "webpack-cli": "^3.1.0",
     "webpack-serve": "^2.0.2"
-  },
-  "dependencies": {}
+  }
 }

--- a/src/InputBox.js
+++ b/src/InputBox.js
@@ -156,13 +156,13 @@ export default class InputBox extends React.Component {
         if (this.props.provider && Object.keys(Providers).includes(this.props.provider)) {
             const Provider = Providers[this.props.provider];
             if (this.props.providerKey) {
-                this.provider = new Provider(this.props.providerKey);
+                this.provider = new Provider({providerKey: this.props.providerKey, searchBounds: this.props.searchBounds});
             } else {
-                this.provider = new Provider();
+                this.provider = new Provider({searchBounds: this.props.searchBounds});
             }
         } else {
             const Provider = Providers.OpenStreetMap;
-            this.provider = new Provider();
+            this.provider = new Provider({searchBounds: this.props.searchBounds});
         }
         if (this.props.search &&
             Array.isArray(this.props.search) &&

--- a/src/InputBox.js
+++ b/src/InputBox.js
@@ -155,14 +155,9 @@ export default class InputBox extends React.Component {
         this.setMaxHeight();
         if (this.props.provider && Object.keys(Providers).includes(this.props.provider)) {
             const Provider = Providers[this.props.provider];
-            if (this.props.providerKey) {
-                this.provider = new Provider({providerKey: this.props.providerKey, searchBounds: this.props.searchBounds});
-            } else {
-                this.provider = new Provider({searchBounds: this.props.searchBounds});
-            }
+            this.provider = new Provider(Object.assign({providerKey: this.props.providerKey, searchBounds: this.props.searchBounds}, this.props.providerOptions));
         } else {
-            const Provider = Providers.OpenStreetMap;
-            this.provider = new Provider({searchBounds: this.props.searchBounds});
+            throw new Error(`You set the provider prop to ${this.props.provider} but that isn't recognised. You can choose from ${Object.keys(Providers).join(", ")}`)
         }
         if (this.props.search &&
             Array.isArray(this.props.search) &&

--- a/src/Providers/BingMap.js
+++ b/src/Providers/BingMap.js
@@ -1,7 +1,14 @@
 class BingMap {
-  constructor(providerkey) {
+  constructor({ providerKey=null, searchBounds=[] } = {}) {
     this.key = providerkey;
-    this.url = `https://dev.virtualearth.net/REST/v1/Locations?output=json&key=${this.key}&q=`
+    //Bounds are expected to be a nested array of [[sw_lat, sw_lng],[ne_lat, ne_lng]].
+    // We convert them into a string of 'x1,y1,x2,y2'
+    let boundsUrlComponent = "";
+    if (searchbounds !== []) {
+      this.bounds = [].concat([],...searchBounds).join(",");
+      boundsUrlComponent = `&umv=${this.bounds}`;
+    }
+    this.url = `https://dev.virtualearth.net/REST/v1/Locations?output=json${boundsUrlComponent}&key=${this.key}&q=`
   }
 
   async search(query) {

--- a/src/Providers/BingMap.js
+++ b/src/Providers/BingMap.js
@@ -1,10 +1,11 @@
 class BingMap {
-  constructor({ providerKey=null, searchBounds=[] } = {}) {
-    this.key = providerkey;
+  constructor(options = { providerKey: null, searchBounds: [] } ) {
+    let { providerKey, searchBounds} = options;
+    this.key = providerKey;
     //Bounds are expected to be a nested array of [[sw_lat, sw_lng],[ne_lat, ne_lng]].
     // We convert them into a string of 'x1,y1,x2,y2'
     let boundsUrlComponent = "";
-    if (searchbounds !== []) {
+    if (searchBounds.length) {
       this.bounds = [].concat([],...searchBounds).join(",");
       boundsUrlComponent = `&umv=${this.bounds}`;
     }

--- a/src/Providers/OpenStreetMap.js
+++ b/src/Providers/OpenStreetMap.js
@@ -2,12 +2,13 @@ class OpenStreetMap {
   constructor(options = { providerKey: null, searchBounds: [] } ) {
     let { providerKey, searchBounds} = options;
     //Bounds are expected to be a nested array of [[sw_lat, sw_lng],[ne_lat, ne_lng]].
-    // We convert them into a string of 'x1,y1,x2,y2'
+    // We convert them into a string of 'x1,y1,x2,y2' which is the opposite way around from lat/lng - it's lng/lat
     let boundsUrlComponent = "";
     let regionUrlComponent = "";
     if (searchBounds.length) {
-      this.bounds = [].concat([],...searchBounds).join(",");
-      boundsUrlComponent = `&viewbox=${this.bounds}`;
+      const reversed = searchBounds.map((el) => {return el.reverse()});
+      this.bounds = [].concat([],...reversed).join(",");
+      boundsUrlComponent = `&bounded=1&viewbox=${this.bounds}`;
     }
     if ('region' in options) {
       regionUrlComponent = `&countrycodes=${options.region}`;

--- a/src/Providers/OpenStreetMap.js
+++ b/src/Providers/OpenStreetMap.js
@@ -1,6 +1,13 @@
 class OpenStreetMap {
-  constructor() {
-    this.url = 'https://nominatim.openstreetmap.org/search?format=json&addressdetails=1&polygon_svg=1&namedetails=1&q='
+  constructor({ providerKey=null, searchBounds=[] } = {}) {
+    //Bounds are expected to be a nested array of [[sw_lat, sw_lng],[ne_lat, ne_lng]].
+    // We convert them into a string of 'x1,y1,x2,y2'
+    let boundsUrlComponent = "";
+    if (searchBounds.length) {
+      this.bounds = [].concat([],...searchBounds).join(",");
+      boundsUrlComponent = `&viewbox=${this.bounds}`;
+    }
+    this.url = `https://nominatim.openstreetmap.org/search?format=json&addressdetails=1&polygon_svg=1&namedetails=1${boundsUrlComponent}&q=`
   }
 
   async search(query) {

--- a/src/Providers/OpenStreetMap.js
+++ b/src/Providers/OpenStreetMap.js
@@ -1,13 +1,18 @@
 class OpenStreetMap {
-  constructor({ providerKey=null, searchBounds=[] } = {}) {
+  constructor(options = { providerKey: null, searchBounds: [] } ) {
+    let { providerKey, searchBounds} = options;
     //Bounds are expected to be a nested array of [[sw_lat, sw_lng],[ne_lat, ne_lng]].
     // We convert them into a string of 'x1,y1,x2,y2'
     let boundsUrlComponent = "";
+    let regionUrlComponent = "";
     if (searchBounds.length) {
       this.bounds = [].concat([],...searchBounds).join(",");
       boundsUrlComponent = `&viewbox=${this.bounds}`;
     }
-    this.url = `https://nominatim.openstreetmap.org/search?format=json&addressdetails=1&polygon_svg=1&namedetails=1${boundsUrlComponent}&q=`
+    if ('region' in options) {
+      regionUrlComponent = `&countrycodes=${options.region}`;
+    }
+    this.url = `https://nominatim.openstreetmap.org/search?format=json&addressdetails=1&polygon_svg=1&namedetails=1${boundsUrlComponent}${regionUrlComponent}&q=`;
   }
 
   async search(query) {

--- a/src/React-Leaflet-Search.js
+++ b/src/React-Leaflet-Search.js
@@ -11,6 +11,8 @@ export default class ReactLeafletSearch extends MapControl {
     constructor(props, context){
         super(props);
         this.div = DomUtil.create('div', 'leaflet-search-wrap');
+        L.DomEvent.disableClickPropagation(this.div);
+        L.DomEvent.disableScrollPropagation(this.div);
         this.state = {
             search: false,
             info: false,

--- a/src/React-Leaflet-Search.js
+++ b/src/React-Leaflet-Search.js
@@ -107,7 +107,8 @@ ReactLeafletSearch.propTypes = {
   showPopup: PropTypes.bool,
   popUp: PropTypes.func,
   closeResultsOnClick: PropTypes.bool,
-  openSearchOnLoad: PropTypes.bool
+  openSearchOnLoad: PropTypes.bool,
+  searchBounds: PropTypes.array
 };
 
 ReactLeafletSearch.defaultProps = {
@@ -115,5 +116,6 @@ ReactLeafletSearch.defaultProps = {
   showMarker: true,
   showPopup: false,
   closeResultsOnClick: false,
-  openSearchOnLoad: false
+  openSearchOnLoad: false,
+  searchBounds: []
 };

--- a/src/React-Leaflet-Search.js
+++ b/src/React-Leaflet-Search.js
@@ -106,10 +106,14 @@ ReactLeafletSearch.propTypes = {
   showMarker: PropTypes.bool,
   showPopup: PropTypes.bool,
   popUp: PropTypes.func,
-}
+  closeResultsOnClick: PropTypes.bool,
+  openSearchOnLoad: PropTypes.bool
+};
 
 ReactLeafletSearch.defaultProps = {
   inputPlaceholder: "Search Lat,Lng",
   showMarker: true,
   showPopup: false,
-}
+  closeResultsOnClick: false,
+  openSearchOnLoad: false
+};

--- a/src/React-Leaflet-Search.js
+++ b/src/React-Leaflet-Search.js
@@ -1,3 +1,4 @@
+import 'babel-polyfill'
 import './react-leaflet-search.css';
 import { Control, DomUtil, icon } from 'leaflet';
 import React from 'react';
@@ -30,9 +31,9 @@ export default class ReactLeafletSearch extends MapControl {
 
     createLeafletElement(props) {
         const ReactLeafletSearch = Control.extend({
-            onAdd: (map) => this.div,
-            onRemove: (map) =>  {}
-        })
+          onAdd: (map) => this.div,
+          onRemove: (map) =>  {}
+        });
         return new ReactLeafletSearch(props);
     }
 

--- a/src/React-Leaflet-Search.js
+++ b/src/React-Leaflet-Search.js
@@ -108,7 +108,10 @@ ReactLeafletSearch.propTypes = {
   popUp: PropTypes.func,
   closeResultsOnClick: PropTypes.bool,
   openSearchOnLoad: PropTypes.bool,
-  searchBounds: PropTypes.array
+  searchBounds: PropTypes.array,
+  region: PropTypes.string,
+  provider: PropTypes.string,
+  providerOptions: PropTypes.object
 };
 
 ReactLeafletSearch.defaultProps = {
@@ -117,5 +120,8 @@ ReactLeafletSearch.defaultProps = {
   showPopup: false,
   closeResultsOnClick: false,
   openSearchOnLoad: false,
-  searchBounds: []
+  searchBounds: [],
+  region: '',
+  provider: 'OpenStreetMap',
+  providerOptions: {}
 };


### PR DESCRIPTION
Hi @tumerorkun 

Thanks for a super library.

I've written a few extra bits which I hope will be generally useful:

- Add an `openSearchOnLoad` boolean prop which allows the input field to be immediately visible when the component is mounted. In our case we'd prefer to have one less click for the user.
- Add a `closeResultsOnClick` boolean prop which hides the search results when you click on one. The results are still stored in the component state, and when focus is on the input form, the results are displayed again. I did this because otherwise the results take up a lot of screen real-estate, which on something with other interactive components is not helpful.
- Add a `searchBounds` prop which takes a nested array of 2 lat/lng pairs. This is passed into the URL for the search provider (although, weirdly, in the case of both OpenStreetMap and Bing it seems to have less effect on the results than I was expecting
- Add a `providerOptions` prop object, which allows you to pass provider-specific stuff. I'm using it in the `OpenStreetMap` provider to search only in one country, by passing `{region: 'gb'}` into that prop. But it could be anything.

I have refactored the way `this.provider` is defined in the `InputBox`, so there isn't the duplication of code, and to allow arbitrary settings to be passed in.

I did consider removing the separate providerKey prop (because you could have it in the providerOptions object) but this would be a breaking change.

Hope this is useful?

Ed