### PR TITLE
Stop SearchCloseButton from submitting forms

### DIFF
--- a/lib/core/search-close-button.js
+++ b/lib/core/search-close-button.js
@@ -3,7 +3,7 @@ function SearchCloseButton({ className = "", onClick = (e) => {
     e.preventDefault();
     e.stopPropagation();
 } }) {
-    return (React.createElement("button", { className: `search-control-close-button${className ? ` ${className}` : ""}`, onClick: onClick },
+    return (React.createElement("button", { className: `search-control-close-button${className ? ` ${className}` : ""}`, onClick: onClick, type: "button" },
         React.createElement("svg", { viewBox: "0 0 50 50" },
             React.createElement("path", { d: "M5 5 L45 45 M45 5 L5 45" }),
             "Sorry, your browser does not support inline SVG.")));


### PR DESCRIPTION
The default behavior of buttons without a type is "submit" when rendered inside a `<form>`. By setting the type to "button" we avoid an annoying bug where closing the search will actually _submit_ the form you are working on.

I think this solves the same problem as https://github.com/tumerorkun/react-leaflet-search/pull/44, but with a smaller and more targeted change.
Fixes https://github.com/tumerorkun/react-leaflet-search/issues/37